### PR TITLE
[17기 이정민] Stay 메인 페이지 레이아웃 구현완료 및 추가 기능 구현 완료

### DIFF
--- a/public/data/StayMainData.json
+++ b/public/data/StayMainData.json
@@ -1,0 +1,52 @@
+{
+  "Discount": [
+    {
+      "id": 1,
+      "DiscountImg": "https://d2ur7st6jjikze.cloudfront.net/cms/1567_original_1614150017.png?1614150017?width=1325"
+    },
+    {
+      "id": 2,
+      "DiscountImg": "https://d2ur7st6jjikze.cloudfront.net/cms/1569_original_1614150018.png?1614150018?width=1325"
+    }
+  ],
+  "Recommend": [
+    {
+      "id": 1,
+      "RecommendImg": "https://d2ur7st6jjikze.cloudfront.net/cms/1577_original_1614330487.png?1614330487?width=1325"
+    },
+    {
+      "id": 2,
+      "RecommendImg": "https://d2ur7st6jjikze.cloudfront.net/cms/1573_original_1614150401.png?1614150401?width=1325"
+    },
+    {
+      "id": 3,
+      "RecommendImg": "https://d2ur7st6jjikze.cloudfront.net/cms/1575_original_1614150403.png?1614150403?width=1325"
+    }
+  ],
+  "SearchCategory": [
+    {
+      "id": 1,
+      "CategoryImg": "https://dffoxz5he03rp.cloudfront.net/icons/ic_accommodation_hotel_40_x_40_colored.svg",
+      "alt": "houseIcon",
+      "name": "호텔·리조트"
+    },
+    {
+      "id": 2,
+      "CategoryImg": "https://dffoxz5he03rp.cloudfront.net/icons/ic_accommodation_pension_40_x_40_colored.svg",
+      "alt": "houseIcon",
+      "name": "펜션·캠핑"
+    },
+    {
+      "id": 3,
+      "CategoryImg": "https://dffoxz5he03rp.cloudfront.net/icons/ic_accommodation_jeju_40_x_40_colored.svg",
+      "alt": "houseIcon",
+      "name": "제주 감성숙소"
+    },
+    {
+      "id": 4,
+      "CategoryImg": "https://dffoxz5he03rp.cloudfront.net/icons/ic_accommodation_month_40_x_40_colored.svg",
+      "alt": "houseIcon",
+      "name": "제주 한달살기"
+    }
+  ]
+}

--- a/src/Pages/Stay/StayMain/Calendar/StayCalendar.js
+++ b/src/Pages/Stay/StayMain/Calendar/StayCalendar.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import 'react-dates/initialize';
+import './datepicker.css';
+import { DateRangePicker } from 'react-dates';
+
+import styled from 'styled-components';
+
+const StayCalendar = ({ setStart, setEnd }) => {
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+  const [date] = useState(new Date());
+  const [focusedInput, setFocusInput] = useState(null);
+
+  const onDatesChange = ({ startDate, endDate }) => {
+    setStartDate(startDate);
+    setEndDate(endDate);
+
+    if (startDate !== null && endDate !== null) {
+      setStart(startDate.format('YYYY-MM-DD'));
+      setEnd(endDate.format('YYYY-MM-DD'));
+    }
+  };
+
+  const formatDate = (date, type) => {
+    let year = date.getFullYear();
+    let month = 1 + date.getMonth();
+    month = month >= 10 ? month : '0' + month;
+    let day = date.getDate() + (type === 'startDate' ? 0 : 1);
+    day = day >= 10 ? day : '0' + day;
+    return year + '-' + month + '-' + day;
+  };
+
+  return (
+    <SearchDateContainer>
+      <DateRangePicker
+        startDatePlaceholderText={formatDate(date, 'startDate')}
+        endDatePlaceholderText={formatDate(date, 'endDate')}
+        startDate={startDate} // momentPropTypes.momentObj or null,
+        startDateId="your_unique_start_date_id" // PropTypes.string.isRequired,
+        endDate={endDate} // momentPropTypes.momentObj or null,
+        endDateId="your_unique_end_date_id" // PropTypes.string.isRequired,
+        onDatesChange={({ startDate, endDate }) =>
+          onDatesChange({ startDate, endDate })
+        }
+        // PropTypes.func.isRequired,
+        focusedInput={focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
+        onFocusChange={focusedInput => setFocusInput(focusedInput)} // PropTypes.func.isRequired,
+        showClearDates={true}
+        displayFormat={() => 'YYYY-MM-DD'}
+      />
+    </SearchDateContainer>
+  );
+};
+
+export default StayCalendar;
+
+const SearchDateContainer = styled.div`
+  width: 100%;
+  cursor: pointer;
+`;

--- a/src/Pages/Stay/StayMain/Calendar/datepicker.css
+++ b/src/Pages/Stay/StayMain/Calendar/datepicker.css
@@ -1,0 +1,898 @@
+.PresetDateRangePicker_panel {
+  padding: 0 22px 11px;
+}
+.PresetDateRangePicker_button {
+  position: relative;
+  height: 100%;
+  text-align: center;
+  background: 0 0;
+  border: 2px solid #2293f6;
+  color: #2293f6;
+  padding: 4px 12px;
+  margin-right: 8px;
+  font: inherit;
+  font-weight: 700;
+  line-height: normal;
+  overflow: visible;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.PresetDateRangePicker_button:active {
+  outline: 0;
+}
+.PresetDateRangePicker_button__selected {
+  color: #fff;
+  background: #2293f6;
+}
+.SingleDatePickerInput {
+  display: inline-block;
+  background-color: #fff;
+}
+.SingleDatePickerInput__withBorder {
+  border-radius: 2px;
+  border: 1px solid #dbdbdb;
+}
+.SingleDatePickerInput__rtl {
+  direction: rtl;
+}
+.SingleDatePickerInput__disabled {
+  background-color: #f2f2f2;
+}
+.SingleDatePickerInput__block {
+  display: block;
+}
+.SingleDatePickerInput__showClearDate {
+  padding-right: 30px;
+}
+.SingleDatePickerInput_clearDate {
+  background: 0 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  padding: 10px;
+  margin: 0 10px 0 5px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+.SingleDatePickerInput_clearDate__default:focus,
+.SingleDatePickerInput_clearDate__default:hover {
+  background: #dbdbdb;
+  border-radius: 50%;
+}
+.SingleDatePickerInput_clearDate__small {
+  padding: 6px;
+}
+.SingleDatePickerInput_clearDate__hide {
+  visibility: hidden;
+}
+.SingleDatePickerInput_clearDate_svg {
+  fill: #82888a;
+  height: 12px;
+  width: 15px;
+  vertical-align: middle;
+}
+.SingleDatePickerInput_clearDate_svg__small {
+  height: 9px;
+}
+.SingleDatePickerInput_calendarIcon {
+  background: 0 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 10px;
+  margin: 0 5px 0 10px;
+}
+.SingleDatePickerInput_calendarIcon_svg {
+  fill: #82888a;
+  height: 15px;
+  width: 14px;
+  vertical-align: middle;
+}
+.SingleDatePicker {
+  position: relative;
+  display: inline-block;
+}
+.SingleDatePicker__block {
+  display: block;
+}
+.SingleDatePicker_picker {
+  z-index: 1;
+  background-color: #fff;
+  position: absolute;
+}
+.SingleDatePicker_picker__rtl {
+  direction: rtl;
+}
+.SingleDatePicker_picker__directionLeft {
+  left: 0;
+}
+.SingleDatePicker_picker__directionRight {
+  right: 0;
+}
+.SingleDatePicker_picker__portal {
+  background-color: rgba(0, 0, 0, 0.3);
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+.SingleDatePicker_picker__fullScreenPortal {
+  background-color: #fff;
+}
+.SingleDatePicker_closeButton {
+  background: 0 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 15px;
+  z-index: 2;
+}
+.SingleDatePicker_closeButton:focus,
+.SingleDatePicker_closeButton:hover {
+  color: darken(#cacccd, 10%);
+  text-decoration: none;
+}
+.SingleDatePicker_closeButton_svg {
+  height: 15px;
+  width: 15px;
+  fill: #cacccd;
+}
+.DayPickerKeyboardShortcuts_buttonReset {
+  background: 0 0;
+  border: 0;
+  border-radius: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  cursor: pointer;
+  font-size: 14px;
+}
+.DayPickerKeyboardShortcuts_buttonReset:active {
+  outline: 0;
+}
+.DayPickerKeyboardShortcuts_show {
+  width: 33px;
+  height: 26px;
+  position: absolute;
+  z-index: 2;
+}
+.DayPickerKeyboardShortcuts_show::before {
+  content: '';
+  display: block;
+  position: absolute;
+}
+.DayPickerKeyboardShortcuts_show__bottomRight {
+  bottom: 0;
+  right: 0;
+}
+.DayPickerKeyboardShortcuts_show__bottomRight::before {
+  border-top: 26px solid transparent;
+  border-right: 33px solid#2293f6;
+  bottom: 0;
+  right: 0;
+}
+.DayPickerKeyboardShortcuts_show__bottomRight:hover::before {
+  border-right: 33px solid #2293f6;
+}
+.DayPickerKeyboardShortcuts_show__topRight {
+  top: 0;
+  right: 0;
+}
+.DayPickerKeyboardShortcuts_show__topRight::before {
+  border-bottom: 26px solid transparent;
+  border-right: 33px solid#2293f6;
+  top: 0;
+  right: 0;
+}
+.DayPickerKeyboardShortcuts_show__topRight:hover::before {
+  border-right: 33px solid #2293f6;
+}
+.DayPickerKeyboardShortcuts_show__topLeft {
+  top: 0;
+  left: 0;
+}
+.DayPickerKeyboardShortcuts_show__topLeft::before {
+  border-bottom: 26px solid transparent;
+  border-left: 33px solid#2293f6;
+  top: 0;
+  left: 0;
+}
+.DayPickerKeyboardShortcuts_show__topLeft:hover::before {
+  border-left: 33px solid #2293f6;
+}
+.DayPickerKeyboardShortcuts_showSpan {
+  color: #fff;
+  position: absolute;
+}
+.DayPickerKeyboardShortcuts_showSpan__bottomRight {
+  bottom: 0;
+  right: 5px;
+}
+.DayPickerKeyboardShortcuts_showSpan__topRight {
+  top: 1px;
+  right: 5px;
+}
+.DayPickerKeyboardShortcuts_showSpan__topLeft {
+  top: 1px;
+  left: 5px;
+}
+.DayPickerKeyboardShortcuts_panel {
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #dbdbdb;
+  border-radius: 2px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 2;
+  padding: 22px;
+  margin: 33px;
+  text-align: left;
+}
+.DayPickerKeyboardShortcuts_title {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0;
+}
+.DayPickerKeyboardShortcuts_list {
+  list-style: none;
+  padding: 0;
+  font-size: 14px;
+}
+.DayPickerKeyboardShortcuts_close {
+  position: absolute;
+  right: 22px;
+  top: 22px;
+  z-index: 2;
+}
+.DayPickerKeyboardShortcuts_close:active {
+  outline: 0;
+}
+.DayPickerKeyboardShortcuts_closeSvg {
+  height: 15px;
+  width: 15px;
+  fill: #cacccd;
+}
+.DayPickerKeyboardShortcuts_closeSvg:focus,
+.DayPickerKeyboardShortcuts_closeSvg:hover {
+  fill: #82888a;
+}
+.CalendarDay {
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: 14px;
+  text-align: center;
+}
+.CalendarDay:active {
+  outline: 0;
+}
+.CalendarDay__defaultCursor {
+  cursor: default;
+}
+.CalendarDay__default {
+  border: 1px solid #e4e7e7;
+  color: #484848;
+  background: #fff;
+}
+.CalendarDay__default:hover {
+  background: #e4e7e7;
+  border: 1px solid #e4e7e7;
+  color: inherit;
+}
+.CalendarDay__hovered_offset {
+  background: #f4f5f5;
+  border: 1px double #e4e7e7;
+  color: inherit;
+}
+.CalendarDay__outside {
+  border: 0;
+  background: #fff;
+  color: #484848;
+}
+.CalendarDay__outside:hover {
+  border: 0;
+}
+.CalendarDay__blocked_minimum_nights {
+  background: #fff;
+  border: 1px solid #eceeee;
+  color: #cacccd;
+}
+.CalendarDay__blocked_minimum_nights:active,
+.CalendarDay__blocked_minimum_nights:hover {
+  background: #fff;
+  color: #cacccd;
+}
+.CalendarDay__highlighted_calendar {
+  background: #ffe8bc;
+  color: #484848;
+}
+.CalendarDay__highlighted_calendar:active,
+.CalendarDay__highlighted_calendar:hover {
+  background: #ffce71;
+  color: #484848;
+}
+.CalendarDay__selected_span {
+  background: #8fc9fb;
+  border: 1px double #8fc9fb;
+  color: #fff;
+}
+.CalendarDay__selected_span:active,
+.CalendarDay__selected_span:hover {
+  background: #8fc9fb;
+  border: 1px double #8fc9fb;
+  color: #fff;
+}
+.CalendarDay__selected,
+.CalendarDay__selected:active,
+.CalendarDay__selected:hover {
+  background: #2293f6;
+  border: 1px double#2293f6;
+  color: #fff;
+}
+.CalendarDay__hovered_span,
+.CalendarDay__hovered_span:hover {
+  background: #8fc9fb;
+  border: 1px double #41a3f8;
+  color: #2293f6;
+}
+.CalendarDay__hovered_span:active {
+  background: #41a3f8;
+  border: 1px double #41a3f8;
+  color: #2293f6;
+}
+.CalendarDay__blocked_calendar,
+.CalendarDay__blocked_calendar:active,
+.CalendarDay__blocked_calendar:hover {
+  background: #cacccd;
+  border: 1px solid #cacccd;
+  color: #82888a;
+}
+.CalendarDay__blocked_out_of_range,
+.CalendarDay__blocked_out_of_range:active,
+.CalendarDay__blocked_out_of_range:hover {
+  background: #fff;
+  border: 1px solid #e4e7e7;
+  color: #cacccd;
+}
+.CalendarDay__hovered_start_first_possible_end {
+  background: #eceeee;
+  border: 1px double #eceeee;
+}
+.CalendarDay__hovered_start_blocked_min_nights {
+  background: #eceeee;
+  border: 1px double #e4e7e7;
+}
+.CalendarMonth {
+  background: #fff;
+  text-align: center;
+  vertical-align: top;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.CalendarMonth_table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+.CalendarMonth_verticalSpacing {
+  border-collapse: separate;
+}
+.CalendarMonth_caption {
+  color: #484848;
+  font-size: 18px;
+  text-align: center;
+  padding-top: 22px;
+  padding-bottom: 37px;
+  caption-side: initial;
+}
+.CalendarMonth_caption__verticalScrollable {
+  padding-top: 12px;
+  padding-bottom: 7px;
+}
+.CalendarMonthGrid {
+  background: #fff;
+  text-align: left;
+  z-index: 0;
+}
+.CalendarMonthGrid__animating {
+  z-index: 1;
+}
+.CalendarMonthGrid__horizontal {
+  position: absolute;
+  left: 9px;
+}
+.CalendarMonthGrid__vertical,
+.CalendarMonthGrid__vertical_scrollable {
+  margin: 0 auto;
+}
+.CalendarMonthGrid_month__horizontal {
+  display: inline-block;
+  vertical-align: top;
+  min-height: 100%;
+}
+.CalendarMonthGrid_month__hideForAnimation {
+  position: absolute;
+  z-index: -1;
+  opacity: 0;
+  pointer-events: none;
+}
+.CalendarMonthGrid_month__hidden {
+  visibility: hidden;
+}
+.DayPickerNavigation {
+  position: relative;
+  z-index: 2;
+}
+.DayPickerNavigation__horizontal {
+  height: 0;
+}
+.DayPickerNavigation__verticalScrollable_prevNav {
+  z-index: 1;
+}
+.DayPickerNavigation__verticalDefault {
+  position: absolute;
+  width: 100%;
+  height: 52px;
+  bottom: 0;
+  left: 0;
+}
+.DayPickerNavigation__verticalScrollableDefault {
+  position: relative;
+}
+.DayPickerNavigation__bottom {
+  height: auto;
+}
+.DayPickerNavigation__bottomDefault {
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+.DayPickerNavigation_button {
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+.DayPickerNavigation_button__default {
+  border: 1px solid #e4e7e7;
+  background-color: #fff;
+  color: #757575;
+}
+.DayPickerNavigation_button__default:focus,
+.DayPickerNavigation_button__default:hover {
+  border: 1px solid #c4c4c4;
+}
+.DayPickerNavigation_button__default:active {
+  background: #f2f2f2;
+}
+.DayPickerNavigation_button__disabled {
+  cursor: default;
+  border: 1px solid #f2f2f2;
+}
+.DayPickerNavigation_button__disabled:focus,
+.DayPickerNavigation_button__disabled:hover {
+  border: 1px solid #f2f2f2;
+}
+.DayPickerNavigation_button__disabled:active {
+  background: 0 0;
+}
+.DayPickerNavigation_button__horizontalDefault {
+  position: absolute;
+  top: 18px;
+  line-height: 0.78;
+  border-radius: 3px;
+  padding: 6px 9px;
+}
+.DayPickerNavigation_bottomButton__horizontalDefault {
+  position: static;
+  margin: -10px 22px 30px;
+}
+.DayPickerNavigation_leftButton__horizontalDefault {
+  left: 22px;
+}
+.DayPickerNavigation_rightButton__horizontalDefault {
+  right: 22px;
+}
+.DayPickerNavigation_button__verticalDefault {
+  padding: 5px;
+  background: #fff;
+  box-shadow: 0 0 5px 2px rgba(0, 0, 0, 0.1);
+  position: relative;
+  display: inline-block;
+  text-align: center;
+  height: 100%;
+  width: 50%;
+}
+.DayPickerNavigation_nextButton__verticalDefault {
+  border-left: 0;
+}
+.DayPickerNavigation_nextButton__verticalScrollableDefault,
+.DayPickerNavigation_prevButton__verticalScrollableDefault {
+  width: 100%;
+}
+.DayPickerNavigation_svg__horizontal {
+  height: 19px;
+  width: 19px;
+  fill: #82888a;
+  display: block;
+}
+.DayPickerNavigation_svg__vertical {
+  height: 42px;
+  width: 42px;
+  fill: #484848;
+}
+.DayPickerNavigation_svg__disabled {
+  fill: #f2f2f2;
+}
+.DayPicker {
+  background: #fff;
+  position: relative;
+  text-align: left;
+}
+.DayPicker__horizontal {
+  background: #fff;
+}
+.DayPicker__verticalScrollable {
+  height: 100%;
+}
+.DayPicker__hidden {
+  visibility: hidden;
+}
+.DayPicker__withBorder {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.07);
+  border-radius: 3px;
+}
+.DayPicker_portal__horizontal {
+  box-shadow: none;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+}
+.DayPicker_portal__vertical {
+  position: initial;
+}
+.DayPicker_focusRegion {
+  outline: 0;
+}
+.DayPicker_calendarInfo__horizontal,
+.DayPicker_wrapper__horizontal {
+  display: inline-block;
+  vertical-align: top;
+}
+.DayPicker_weekHeaders {
+  position: relative;
+}
+.DayPicker_weekHeaders__horizontal {
+  margin-left: 9px;
+}
+.DayPicker_weekHeader {
+  color: #757575;
+  position: absolute;
+  top: 62px;
+  z-index: 2;
+  text-align: left;
+}
+.DayPicker_weekHeader__vertical {
+  left: 50%;
+}
+.DayPicker_weekHeader__verticalScrollable {
+  top: 0;
+  display: table-row;
+  border-bottom: 1px solid #dbdbdb;
+  background: #fff;
+  margin-left: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+}
+.DayPicker_weekHeader_ul {
+  list-style: none;
+  margin: 1px 0;
+  padding-left: 0;
+  padding-right: 0;
+  font-size: 14px;
+}
+.DayPicker_weekHeader_li {
+  display: inline-block;
+  text-align: center;
+}
+.DayPicker_transitionContainer {
+  position: relative;
+  overflow: hidden;
+  border-radius: 3px;
+}
+.DayPicker_transitionContainer__horizontal {
+  -webkit-transition: height 0.2s ease-in-out;
+  -moz-transition: height 0.2s ease-in-out;
+  transition: height 0.2s ease-in-out;
+}
+.DayPicker_transitionContainer__vertical {
+  width: 100%;
+}
+.DayPicker_transitionContainer__verticalScrollable {
+  padding-top: 20px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  overflow-y: scroll;
+}
+.DateInput {
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  position: relative;
+  display: inline-block;
+  width: 100px;
+  vertical-align: middle;
+  border: 0;
+}
+.DateInput__small {
+  width: 97px;
+}
+.DateInput__block {
+  width: 100%;
+}
+.DateInput__disabled {
+  background: #f2f2f2;
+  color: #dbdbdb;
+  border: 0;
+}
+.DateInput_input {
+  font-weight: 200;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px;
+  color: rgb(52, 58, 64);
+  /* color: red; */
+  background-color: rgb(245, 246, 247);
+  outline: none;
+  width: 100%;
+  padding: 11px 11px 9px;
+  border: 0;
+  border-top: 0;
+  border-right: 0;
+  border-bottom: 2px solid transparent;
+  border-left: 0;
+  border-radius: 0;
+}
+::-webkit-input-placeholder {
+  color: rgb(52, 58, 64);
+}
+.DateInput_input__small {
+  font-size: 15px;
+  line-height: 18px;
+  letter-spacing: 0.2px;
+  padding: 7px 7px 5px;
+}
+.DateInput_input__regular {
+  font-weight: auto;
+}
+.DateInput_input__readOnly {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.DateInput_input__focused {
+  outline: 0;
+  background-color: rgb(245, 246, 247);
+  border: 0;
+  border-top: 0;
+  border-right: 0;
+  /* border-bottom: 2px solid #2293f6; */
+  border-left: 0;
+}
+.DateInput_input__disabled {
+  background: #f2f2f2;
+  font-style: italic;
+}
+.DateInput_screenReaderMessage {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.DateInput_fang {
+  position: absolute;
+  width: 20px;
+  height: 10px;
+  left: 22px;
+  z-index: 2;
+}
+.DateInput_fangShape {
+  fill: #fff;
+}
+.DateInput_fangStroke {
+  stroke: #dbdbdb;
+  fill: transparent;
+}
+.DateRangePickerInput {
+  background-color: #fff;
+  display: inline-block;
+}
+.DateRangePickerInput__disabled {
+  background: #f2f2f2;
+}
+.DateRangePickerInput__withBorder {
+  /* border-radius: 3px; */
+  border: none;
+  background-color: rgb(245, 246, 247);
+}
+.DateRangePickerInput__rtl {
+  direction: rtl;
+}
+.DateRangePickerInput__block {
+  display: block;
+}
+.DateRangePickerInput__showClearDates {
+  padding-right: 30px;
+}
+.DateRangePickerInput_arrow {
+  display: inline-block;
+  vertical-align: middle;
+  color: #484848;
+  /* background-color: rgb(245, 246, 247); */
+}
+.DateRangePickerInput_arrow_svg {
+  vertical-align: middle;
+  fill: rgb(52, 58, 64);
+  /* background-color: rgb(245, 246, 247); */
+  height: 22px;
+  width: 22px;
+}
+.DateRangePickerInput_clearDates {
+  background: 0 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  padding: 10px;
+  margin: 0 10px 0 5px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+.DateRangePickerInput_clearDates__small {
+  padding: 6px;
+}
+.DateRangePickerInput_clearDates_default:focus,
+.DateRangePickerInput_clearDates_default:hover {
+  background: #dbdbdb;
+  border-radius: 50%;
+}
+.DateRangePickerInput_clearDates__hide {
+  visibility: hidden;
+}
+.DateRangePickerInput_clearDates_svg {
+  fill: #82888a;
+  height: 12px;
+  width: 15px;
+  vertical-align: middle;
+}
+.DateRangePickerInput_clearDates_svg__small {
+  height: 9px;
+}
+.DateRangePickerInput_calendarIcon {
+  background: 0 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 10px;
+  margin: 0 5px 0 10px;
+}
+.DateRangePickerInput_calendarIcon_svg {
+  fill: #82888a;
+  height: 15px;
+  width: 14px;
+  vertical-align: middle;
+}
+.DateRangePicker {
+  position: relative;
+  display: inline-block;
+  background-color: rgb(245, 246, 247);
+}
+.DateRangePicker__block {
+  display: block;
+}
+.DateRangePicker_picker {
+  z-index: 99;
+  background-color: #fff;
+  position: absolute;
+}
+.DateRangePicker_picker__rtl {
+  direction: rtl;
+}
+.DateRangePicker_picker__directionLeft {
+  left: 0;
+}
+.DateRangePicker_picker__directionRight {
+  right: 0;
+}
+.DateRangePicker_picker__portal {
+  background-color: rgba(0, 0, 0, 0.3);
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+.DateRangePicker_picker__fullScreenPortal {
+  background-color: #fff;
+}
+.DateRangePicker_closeButton {
+  background: 0 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 15px;
+  z-index: 2;
+}
+.DateRangePicker_closeButton:focus,
+.DateRangePicker_closeButton:hover {
+  color: darken(#cacccd, 10%);
+  text-decoration: none;
+}
+.DateRangePicker_closeButton_svg {
+  height: 15px;
+  width: 15px;
+  fill: #cacccd;
+}

--- a/src/Pages/Stay/StayMain/Components/SearchContainer.js
+++ b/src/Pages/Stay/StayMain/Components/SearchContainer.js
@@ -1,0 +1,310 @@
+import React, { useEffect, useState } from 'react';
+import { withRouter, useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+import theme from '../../../../Styles/theme';
+import StayCalendar from '../Calendar/StayCalendar';
+
+const MAX_ADULT_NUM = 9;
+const MAX_ROOM_NUM = 9;
+
+const SearchContainer = () => {
+  const [place] = useState('제주');
+  const [adult, setAdult] = useState(1);
+  const [room, setRoom] = useState(1);
+  const [start, setStart] = useState(new Date());
+  const [end, setEnd] = useState(new Date());
+  const [isUserBoxToggle, setIsUserBoxToggle] = useState(false);
+
+  const history = useHistory();
+
+  const handleAdultAdd = () => {
+    adult === MAX_ADULT_NUM
+      ? alert('최대 정원 9명까지만 가능합니다.')
+      : setAdult(adult + 1);
+  };
+
+  const handleAdultMinus = () => {
+    adult > 1 && setAdult(adult - 1);
+  };
+
+  const handleRoomAdd = () => {
+    room === MAX_ROOM_NUM
+      ? alert('최대 9 객실까지 가능합니다.')
+      : setRoom(room + 1);
+  };
+
+  const handRoomMinus = () => {
+    room > 1 && setRoom(room - 1);
+  };
+  const handleUserBoxToggle = () => {
+    setIsUserBoxToggle(!isUserBoxToggle);
+  };
+  const handleUserBoxClose = () => {
+    setIsUserBoxToggle(false);
+  };
+
+  const handleSearchResult = () => {
+    const newObj = {
+      city: place,
+      startDate: start,
+      endDate: end,
+      guest: adult,
+    };
+
+    return (
+      '?' +
+      Object.entries(newObj)
+        .map(e => e.join('='))
+        .join('&')
+    );
+  };
+
+  const formatDate = type => {
+    let defaultDate = new Date();
+    let year = defaultDate.getFullYear();
+    let month = 1 + defaultDate.getMonth();
+    month = month >= 10 ? month : '0' + month;
+    if (type === 'startDate') {
+      let day = defaultDate.getDate();
+      day = day >= 10 ? day : '0' + day;
+      return year + '-' + month + '-' + day;
+    } else if (type === 'endDate') {
+      let day = 1 + defaultDate.getDate();
+      day = day >= 10 ? day : '0' + day;
+      return year + '-' + month + '-' + day;
+    }
+  };
+
+  useEffect(() => {
+    setStart(formatDate('startDate'));
+    setEnd(formatDate('endDate'));
+  }, []);
+
+  const goToList = () => {
+    console.log('보내주는값 > > ', handleSearchResult());
+    history.push('./staylist', handleSearchResult());
+  };
+  return (
+    <>
+      <SearchMain>
+        <div className="searchPlace">
+          <i className="fas fa-map-marker-alt" />
+          <span>제주도</span>
+        </div>
+        <div className="searchDate">
+          <i className="fas fa-calendar" />
+          <StayCalendar setStart={setStart} setEnd={setEnd} />
+          <i className="fas fa-chevron-down rightDown" />
+        </div>
+        <div className="searchUser">
+          <div onClick={handleUserBoxToggle}>
+            <i className="fas fa-user" />
+            <span>
+              성인 {adult}명 / 객실 {room}개
+            </span>
+            <i className="fas fa-chevron-down rightDown" />
+          </div>
+          <StaySelectUser display={isUserBoxToggle}>
+            <div className="selectUserBoxTitle">인원선택</div>
+            <div className="selectUserBoxInner">
+              <span className="innerTitle">성인</span>
+              <div className="innerBtn">
+                <button onClick={handleAdultMinus}>-</button>
+                {adult}
+                <button onClick={handleAdultAdd}>+</button>
+              </div>
+            </div>
+            <div className="selectUserBoxInner">
+              <span className="innerTitle">객실</span>
+              <div className="innerBtn">
+                <button onClick={handRoomMinus}>-</button>
+                {room}
+                <button onClick={handleRoomAdd}>+</button>
+              </div>
+            </div>
+            <button className="selectUserBoxBtn" onClick={handleUserBoxClose}>
+              적용하기
+            </button>
+          </StaySelectUser>
+        </div>
+        <button className="searchBtn" onClick={goToList}>
+          검색
+        </button>
+      </SearchMain>
+    </>
+  );
+};
+
+export default withRouter(SearchContainer);
+
+const SearchMain = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+
+  .searchPlace {
+    display: flex;
+    align-items: center;
+    width: 270px;
+    height: 50px;
+    background-color: rgb(245, 246, 247);
+    border-radius: 5px;
+    font-size: 16px;
+    padding-left: 15px;
+    cursor: pointer;
+    i {
+      margin-right: 10px;
+      color: ${theme.Color.gray['dark']};
+    }
+    &:hover {
+      border: 1px solid rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  .searchDate {
+    display: flex;
+    align-items: center;
+    width: 340px;
+    height: 50px;
+    background-color: rgb(245, 246, 247);
+    border-radius: 5px;
+    font-size: 16px;
+    padding-left: 15px;
+    cursor: pointer;
+    i {
+      margin-right: 10px;
+      color: ${theme.Color.gray['dark']};
+    }
+
+    p {
+      margin-right: 80px;
+      color: ${theme.Color.gray['dark']};
+    }
+    &:hover {
+      border: 1px solid rgba(0, 0, 0, 0.5);
+    }
+  }
+  .searchUser {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 270px;
+    height: 50px;
+    background-color: rgb(245, 246, 247);
+    border-radius: 5px;
+    font-size: 16px;
+    padding-left: 15px;
+    cursor: pointer;
+    i {
+      margin-right: 10px;
+      color: ${theme.Color.gray['dark']};
+    }
+
+    span {
+      margin-right: 80px;
+      color: ${theme.Color.gray['dark']};
+    }
+    &:hover {
+      border: 1px solid rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  .searchBtn {
+    width: 95px;
+    height: 50px;
+    background-color: ${theme.Color.blue['light']};
+    color: white;
+    font-size: 16px;
+    font-weight: bold;
+    border-radius: 10px;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    &:hover {
+      background-color: rgb(43, 150, 237);
+    }
+  }
+`;
+
+const StaySelectUser = styled.div`
+  position: absolute;
+  display: ${props => (props.display ? 'flex' : 'none')};
+  flex-direction: column;
+  width: 300px;
+  height: 240px;
+  top: 55px;
+  right: -30px;
+  padding: 16px;
+  background-color: #fff;
+  border-radius: 4px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+
+  .selectUserBoxTitle {
+    margin: 0px 0px 30px;
+    font-size: 18px;
+    font-weight: bold;
+    color: ${theme.Color.gray['dark']};
+  }
+
+  .selectUserBoxInner {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: 30px;
+
+    .innerTitle {
+      font-size: 18px;
+      font-weight: 600;
+      color: ${theme.Color.gray['dark']};
+    }
+
+    .innerBtn {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      button {
+        background: none;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+        outline: none;
+        border: 1px solid ${theme.Color.blue['light']};
+        color: ${theme.Color.blue['light']};
+        font-size: 20px;
+        font-weight: 500;
+        margin: 0px 8px;
+        cursor: pointer;
+
+        &:hover {
+          background-color: rgb(245, 251, 255);
+        }
+      }
+    }
+  }
+  .selectUserBoxBtn {
+    position: absolute;
+    bottom: 15px;
+    right: 15px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    border: none;
+    border-radius: 5px;
+    color: white;
+    background-color: ${theme.Color.blue['light']};
+    width: 75px;
+    height: 30px;
+    font-size: 14px;
+    cursor: pointer;
+    &:hover {
+      background-color: rgb(43, 150, 237);
+    }
+  }
+`;

--- a/src/Pages/Stay/StayMain/Components/StayMainDiscount.js
+++ b/src/Pages/Stay/StayMain/Components/StayMainDiscount.js
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import theme from '../../../../Styles/theme';
+
+const StayMainDiscount = () => {
+  const [disCountArr, setDisCountArr] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/StayMainData.json')
+      .then(res => res.json())
+      .then(data => {
+        setDisCountArr(data.Discount);
+      });
+  }, []);
+  return (
+    <Discount>
+      <DiscountTitle>할인 혜택</DiscountTitle>
+      <DiscountCardList>
+        {disCountArr.map(data => {
+          return (
+            <DiscountCard
+              src={data.DiscountImg}
+              alt="DiscountCard"
+              key={data.id}
+            />
+          );
+        })}
+      </DiscountCardList>
+    </Discount>
+  );
+};
+
+export default StayMainDiscount;
+
+const Discount = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 200px;
+  margin-top: 40px;
+`;
+
+const DiscountTitle = styled.h2`
+  font-size: 26px;
+  font-weight: 600;
+  color: ${theme.Color.gray['dark']};
+  margin-bottom: 20px;
+`;
+
+const DiscountCardList = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+`;
+
+const DiscountCard = styled.img`
+  width: 510px;
+  height: 100%;
+  border-radius: 10px;
+  border: none;
+  outline: none;
+  cursor: pointer;
+`;

--- a/src/Pages/Stay/StayMain/Components/StayMainRecommend.js
+++ b/src/Pages/Stay/StayMain/Components/StayMainRecommend.js
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import theme from '../../../../Styles/theme';
+
+const StayMainRecommend = () => {
+  const [recommendArr, setRecommendArr] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/StayMainData.json')
+      .then(res => res.json())
+      .then(data => {
+        setRecommendArr(data.Recommend);
+      });
+  }, []);
+
+  return (
+    <Recommend>
+      <RecommendTitle>에디터 추천</RecommendTitle>
+      <RecommendCardList>
+        {recommendArr.map(data => {
+          return (
+            <RecommendCard
+              src={data.RecommendImg}
+              alt="RecommendCard"
+              key={data.id}
+            />
+          );
+        })}
+      </RecommendCardList>
+    </Recommend>
+  );
+};
+
+export default StayMainRecommend;
+
+const Recommend = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 290px;
+  margin-top: 60px;
+`;
+
+const RecommendTitle = styled.h2`
+  font-size: 26px;
+  font-weight: 600;
+  color: ${theme.Color.gray['dark']};
+  margin-bottom: 20px;
+`;
+
+const RecommendCardList = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+`;
+
+const RecommendCard = styled.img`
+  width: 340px;
+  height: 100%;
+  border-radius: 10px;
+  border: none;
+  outline: none;
+  cursor: pointer;
+`;

--- a/src/Pages/Stay/StayMain/Components/StayMainSearchCategory.js
+++ b/src/Pages/Stay/StayMain/Components/StayMainSearchCategory.js
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+const StayMainSearchCategory = () => {
+  const [cateArr, setCateArr] = useState([]);
+
+  useEffect(() => {
+    fetch('/data/StayMainData.json')
+      .then(res => res.json())
+      .then(data => {
+        setCateArr(data.SearchCategory);
+      });
+  }, []);
+
+  return (
+    <SearchCategory>
+      {cateArr.map(data => {
+        return (
+          <div className="categoryDiv" key={data.id}>
+            <img src={data.CategoryImg} alt={data.alt} />
+            <span>{data.name}</span>
+          </div>
+        );
+      })}
+    </SearchCategory>
+  );
+};
+
+export default StayMainSearchCategory;
+
+const SearchCategory = styled.div`
+  display: flex;
+  align-items: center;
+  text-align: center;
+
+  .categoryDiv {
+    display: flex;
+    img {
+      width: 20px;
+      height: 20px;
+      border: 0px;
+    }
+    span {
+      font-size: 16px;
+      font-weight: bold;
+      margin-left: 5px;
+      margin-right: 30px;
+      color: rgb(73, 80, 86);
+      cursor: pointer;
+    }
+  }
+`;

--- a/src/Pages/Stay/StayMain/StayMain.js
+++ b/src/Pages/Stay/StayMain/StayMain.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import StayMainDiscount from './Components/StayMainDiscount';
+import StayMainRecommend from './Components/StayMainRecommend';
+import StayMainSearchCategory from './Components/StayMainSearchCategory';
+import SearchContainer from './Components/SearchContainer';
+
+const StayMain = () => {
+  return (
+    <StayMainContainer>
+      <StaySection>
+        <SearchSection>
+          <Title>어떤 숙소 찾으세요?</Title>
+          <SearchDiv>
+            <StayMainSearchCategory />
+            <SearchContainer />
+          </SearchDiv>
+        </SearchSection>
+        <StayMainDiscount />
+        <StayMainRecommend />
+      </StaySection>
+    </StayMainContainer>
+  );
+};
+
+export default StayMain;
+
+const StayMainContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  margin-bottom: 130px;
+`;
+
+const StaySection = styled.div`
+  width: 1060px;
+  height: 100%;
+  margin: 0 auto;
+  padding-top: 40px;
+`;
+
+const SearchSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 210px;
+`;
+
+const Title = styled.h1`
+  font-size: 40px;
+  font-weight: bold;
+  position: absolute;
+  color: #ffffff;
+`;
+
+const SearchDiv = styled.div`
+  width: 100%;
+  height: 145px;
+  margin-top: 70px;
+  padding: 15px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  background-color: white;
+
+  z-index: 1;
+`;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -31,7 +31,7 @@ class Routes extends Component {
       <Router>
         {this.navHandler()}
         <Switch>
-          <Route exact path="/" component={Airline} />
+          <Route exact path="/staymain" component={StayMain} />
         </Switch>
         <Footer />
       </Router>


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
(여기에 수정 사항에 대한 간략한 한줄 요약/제목 작성해 주세요.)
- Stay 메인 페이지 레이아웃 구현완료 및 추가 기능 구현 완료
		 
## 수정 사항들 자세한 내용
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- Stay 메인 페이지 구현중 commit (03.03)
1. react-dates API 이용하여 캘린더 부분 구현완료
2. 메인페이지 전체 레이아웃 구현완료
3. 객실 및 인원 수 모달 창 구현완료
4. 플러스버튼 마이너스버튼 마다 객실 및 인원 수 state값 증감 완료

- 첫번째 피드백 완료 commit (03.04)
1. 주석 처리 완료
2. 조건문 삼항연산자로 변환 완료
3. 객실 및 인원 수 모달 창 위치 조정 완료

- 두번째 피드백 완료 commit (03.04)
1. fetch의 get 제거
2. 부등호 반대와 삼항연산자를 조건부렌더링으로 변환

- 세번째 피드백 완료 (03.09)
1. theme 컬러 적용

- Stay 메인 페이지 레이아웃 구현완료 및 추가 기능 구현 완료 (03.06~03.07)
1. react-dates API 사용하여 달력 구현 완료 format 변환 완료
2. 장소와 달력 인원 값을 쿼리스트링으로 변환 완료
2. history.push의 두번째 인자값을 이용해 페이지 이동하면서 쿼리스트링 location.state로 값 전달 완료

- Stay 메인 페이지 레이아웃 구현완료 및 추가 기능 구현 완료 (03.08)
1. 달력 state 값 축소
2. 기존 검색 시 그냥 값이동 되던 부분 default date값 format 후 적용 완료
3. 피드백 적용 완료


## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점들 공유해주실 것이 있으면 자유롭게 작성해 주세요.)

**질문**

1. 달력api에서 format으로 변환해주어야 하기에 값을 state의 두번으로 중복해서 받고있습니다
왜냐하면 처음에 startDate, endDate는 moment 라는 객체로 받아지기 때문에 YYYY-MM-DD로 변경해주어야합니다.
또한 값을 부모로 onCreate 라는 props로 내려온 함수로 올려주고 있어 변환을 해줘서 보내야 하는데 두번에 걸치지 않을 수
있는 방법이 있을가요 ? <해결완료>

![달력1](https://user-images.githubusercontent.com/65124480/110248143-f9653d80-7fb2-11eb-963f-4d0cd9d657b5.PNG)


2. 그렇게 넘어온 데이터는 쿼리스트링으로 변환되는 로직을 통하여 다른 값들과 쿼리문으로 변경됩니다
허나 달력을 찍어서 눌러보면 두번째 찍어서 눌러야만 값이 담기는 기이한 현상이 일어납니다 렌더 순서의 문제 같은데
1번 문제와 연관이 있는것 같습니다.. 어떻게 해야할가요? <해결완료>

![달력2](https://user-images.githubusercontent.com/65124480/110248212-4a753180-7fb3-11eb-8d7d-f655d38158b0.PNG)


## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
